### PR TITLE
Fixed quote rendering issue for getQuoteByPerson and createQuote APIs

### DIFF
--- a/quotes-router.js
+++ b/quotes-router.js
@@ -42,8 +42,7 @@ quotesRouter.get('/', (req, res, next) => {
     if (allNames.indexOf(queryPerson) !== -1) {
       // filter to quote objects associated with the name and reduce into a single array to return
       const quotesByName = quotes
-        .filter((element) => element.person == queryPerson)
-        .reduce(flattenQuoteArray, []);
+        .filter((element) => element.person == queryPerson);
       responseObject.quotes = quotesByName;
       res.send(responseObject);
     } else {
@@ -53,7 +52,7 @@ quotesRouter.get('/', (req, res, next) => {
   } else {
     // if no person specified, return all quotes
     // reduce into a single array of just quotes
-    const allQuotes = quotes.reduce(flattenQuoteArray, []);
+    const allQuotes = quotes;
     responseObject.quotes = allQuotes;
     res.send(responseObject);
   }


### PR DESCRIPTION
I updated the response format for getQuoteByPerson and createQuote APIs to match what the front end expects:

**Before:**
``` JSON
{
  "quotes": ["quote 1", "quote 2", "quote 3"]
}
```

**After:**
``` JSON
{
    "quotes": [
        {
            "quote": "If it's a good idea, go ahead and do it. It's much easier to apologize than it is to get permission.",
            "person": "Grace Hopper"
        },
        {
            "quote": "The most dangerous phrase in the language is, \"We've always done it this way.\"",
            "person": "Grace Hopper"
        }
    ]
}
```
